### PR TITLE
Add polyphony to Shaper module

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -188,7 +188,8 @@
       "tags": [
         "Distortion",
         "Effect",
-        "Waveshaper"
+        "Waveshaper",
+		"Polyphonic"
       ]
     }
   ]


### PR DESCRIPTION
This adds ployphony support to the Shaper module only. The In and Out are now polyphonic, and the Amount input of the Shaper module will also handle polyphonic inputs if they are attached.