### PR TITLE
Fix typo in Chaos docs

### DIFF
--- a/docs/Topics/Chaos.md
+++ b/docs/Topics/Chaos.md
@@ -12,7 +12,7 @@ HetrickCV contains a wide number of modules with chaotic or pseudorandom behavio
 - [Gingerbread Chaos](../Modules/Gingerbread.md)
 - [Rungler](../Modules/Rungler.md)
 
-### (Psuedo) Random Modules:
+### (Pseudo) Random Modules:
 - [Binary Noise](../Modules/BinaryNoise.md)
 - [Clocked Noise](../Modules/ClockedNoise.md)
 - [Dust](../Modules/Dust.md)


### PR DESCRIPTION
## Summary
- fix spelling of "(Pseudo) Random Modules" heading in docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851f017268c832ba164260db97dfc94