### PR TITLE
Fix shift register initialization bug

### DIFF
--- a/src/DSP/HCVShiftRegister.h
+++ b/src/DSP/HCVShiftRegister.h
@@ -13,7 +13,7 @@ public:
     {
         dataRegister.resize(size);
 
-        for(auto dataReg : dataRegister)
+        for(auto& dataReg : dataRegister)
         {
             dataReg = T(0);
         }


### PR DESCRIPTION
## Summary
- fix initialization loop in `HCVShiftRegister`

## Testing
- `make` *(fails: `../Rack-SDK/plugin.mk: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6851e53fbb20832b963b618a076a5e29